### PR TITLE
Use monospace font for .log-line

### DIFF
--- a/src/frontend/src/components/TaskItem.vue
+++ b/src/frontend/src/components/TaskItem.vue
@@ -210,6 +210,7 @@ export default {
     white-space: pre-wrap;
     word-break: break-word;
     font-size: 95%;
+    font-family: monospace;
 }
 @media (max-width: 600px) {
     .log-container {


### PR DESCRIPTION
For some confusing reason `beercss` override monospace font for `<pre>`.

Now it need to be explicitly specified, otherwise we get dancing formatting:

![image](https://github.com/user-attachments/assets/6c416997-65c1-4b96-8ab2-ba06430c60b3)
